### PR TITLE
Allow Python 3.11

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ['3.8','3.9','3.10','3.11']
 
     steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install host dependencies
@@ -30,7 +30,7 @@ jobs:
         python -m pip install --user --force \
             'tox < 4'
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Pylint
       run: |
@@ -48,7 +48,7 @@ jobs:
         python-version: ['3.8','3.9','3.10','3.11']
 
     steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install host dependencies
@@ -59,7 +59,7 @@ jobs:
         python -m pip install --user --force \
             'tox < 4'
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: tests with coverage
       run: |

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -28,7 +28,7 @@ jobs:
         python --version
         python -m pip install --upgrade pip
         python -m pip install --user --force \
-            tox
+            'tox < 4'
 
     - uses: actions/checkout@v2
 
@@ -57,7 +57,7 @@ jobs:
         python --version
         python -m pip install --upgrade pip
         python -m pip install --user --force \
-            tox
+            'tox < 4'
 
     - uses: actions/checkout@v2
 

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7','3.8','3.9','3.10']
+        python-version: ['3.8','3.9','3.10','3.11']
 
     steps:
     - uses: actions/setup-python@v2
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7','3.8','3.9','3.10']
+        python-version: ['3.8','3.9','3.10','3.11']
 
     steps:
     - uses: actions/setup-python@v2

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Tox environments. The dependencies of tested package if any are not touched.
 This is mostly used for testing purposes in ALTLinux during RPM build of Python
 packages to run integration tests against the repository packages.
 
+Note
+-----
+
+Only `tox < 4` is supported for now.
+
 Usage
 -----
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ package_dir =
 zip_safe = True
 python_requires = >=3.8
 install_requires =
-    tox
+    tox < 4
     pluggy
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,8 @@ project_urls =
     Tracker=https://github.com/stanislavlevin/tox-no-deps/issues
 platforms = any
 license = MIT
-license_file = LICENSE
+license_files =
+    LICENSE
 classifiers =
     Development Status :: 4 - Beta
     Framework :: tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,17 +23,17 @@ classifiers =
     Topic :: Software Development :: Testing
     Topic :: Software Development :: Libraries
     Topic :: Utilities
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 packages = find:
 package_dir =
   =src
 zip_safe = True
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     tox
     pluggy

--- a/tests/integration/test_tox_no_deps_int.py
+++ b/tests/integration/test_tox_no_deps_int.py
@@ -74,7 +74,7 @@ def test_no_plugin_usage_extras(tox_project, tox):
     result = tox("-vv", cwd=project.location)
     result.assert_fail()
     assert (
-        "No matching distribution found for somenotexisted_package1==9.9.9\n"
+        "No matching distribution found for somenotexisted_package1==9.9.9"
     ) in result.stdout_text
 
 


### PR DESCRIPTION
- dropped support for Python3.7
- fixed tests against Python 3.11
- marked tox 4 as unsupported