### PR TITLE
deblack: reformat against black 26.1.0

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v5
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tox-no-deps"
 description = "Skip an installation of dependencies of tox test environments"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 dependencies = [
   "tox > 4",
 ]
@@ -30,7 +30,6 @@ classifiers = [
   "Topic :: Utilities",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/src/tox_no_deps/plugin.py
+++ b/src/tox_no_deps/plugin.py
@@ -3,7 +3,6 @@ import logging
 from tox.config.loader.memory import MemoryLoader
 from tox.plugin import impl
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -36,9 +36,7 @@ def test_plugin_usage_deps(tox_project):
     """
     project = tox_project()
     env_name = "py"
-    project.contents[
-        "tox.ini"
-    ] = f"""\
+    project.contents["tox.ini"] = f"""\
         [tox]
         env_list = {env_name}
         [testenv]
@@ -71,9 +69,7 @@ def test_plugin_usage_extras(tox_project):
     """
     project = tox_project()
     env_name = "py"
-    project.contents[
-        "pyproject.toml"
-    ]: f"""\
+    project.contents["pyproject.toml"] = f"""\
         [project]
         name = "{project.name}"
         version = "1.0"
@@ -84,9 +80,7 @@ def test_plugin_usage_extras(tox_project):
           "bar2_bar2",
         ]
         """
-    project.contents[
-        "tox.ini"
-    ] = f"""\
+    project.contents["tox.ini"] = f"""\
         [tox]
         env_list = {env_name}
         [testenv]
@@ -117,9 +111,7 @@ def test_plugin_usage_dependency_groups(tox_project):
     """
     project = tox_project()
     env_name = "py"
-    project.contents[
-        "pyproject.toml"
-    ]: f"""\
+    project.contents["pyproject.toml"] = f"""\
         [project]
         name = "{project.name}"
         version = "1.0"
@@ -130,9 +122,7 @@ def test_plugin_usage_dependency_groups(tox_project):
            "bar2_bar2",
         ]
         """
-    project.contents[
-        "tox.ini"
-    ] = f"""\
+    project.contents["tox.ini"] = f"""\
         [tox]
         env_list = {env_name}
         [testenv]
@@ -161,9 +151,7 @@ def test_plugin_usage_no_deps(tox_project):
     """
     project = tox_project()
     env_name = "py"
-    project.contents[
-        "tox.ini"
-    ] = f"""\
+    project.contents["tox.ini"] = f"""\
         [tox]
         env_list = {env_name}
         [testenv]
@@ -191,9 +179,7 @@ def test_no_plugin_usage(tox_project):
     """
     project = tox_project()
     env_name = "py"
-    project.contents[
-        "tox.ini"
-    ] = f"""\
+    project.contents["tox.ini"] = f"""\
         [tox]
         env_list = {env_name}
         [testenv]


### PR DESCRIPTION
See for details:
https://black.readthedocs.io/en/stable/change_log.html

Fixes: https://github.com/stanislavlevin/tox-no-deps/issues/18

## Summary by Sourcery

Reformat code to comply with the Black 26.1.0 style configuration across tests and plugin module.

Enhancements:
- Simplify project contents assignments in tests for tox configuration and project metadata files.
- Remove an unnecessary blank line in the plugin module to align with updated formatting rules.